### PR TITLE
Add param parsing for auto pullspring feature

### DIFF
--- a/aiotedee/lock.py
+++ b/aiotedee/lock.py
@@ -34,6 +34,7 @@ class TedeeLock:
         is_charging: bool = False,
         state_change_result: int = 0,
         is_enabled_pullspring: bool = False,
+        is_enabled_auto_pullspring: bool = False,
         duration_pullspring: int = 0,
     ) -> None:
         """Initialize a new lock."""
@@ -47,6 +48,7 @@ class TedeeLock:
         self._state_change_result = state_change_result
         self._duration_pullspring = duration_pullspring
         self._is_enabled_pullspring = is_enabled_pullspring
+        self._is_enabled_auto_pullspring = is_enabled_auto_pullspring
 
     @property
     def lock_name(self) -> str:
@@ -138,6 +140,15 @@ class TedeeLock:
         self._is_enabled_pullspring = value
 
     @property
+    def is_enabled_auto_pullspring(self) -> bool:
+        """Return true if the lock is charging."""
+        return bool(self._is_enabled_auto_pullspring)
+
+    @is_enabled_auto_pullspring.setter
+    def is_enabled_auto_pullspring(self, value: bool):
+        self._is_enabled_auto_pullspring = value    
+
+    @property
     def duration_pullspring(self) -> int:
         """Return the duration of the pullspring."""
         return self._duration_pullspring
@@ -158,5 +169,6 @@ class TedeeLock:
             "is_charging": self._is_charging,
             "state_change_result": self._state_change_result,
             "is_enabled_pullspring": self._is_enabled_pullspring,
+            "is_enabled_auto_pullspring": self._is_enabled_auto_pullspring,
             "duration_pullspring": self._duration_pullspring,
         }

--- a/aiotedee/tedee_client.py
+++ b/aiotedee/tedee_client.py
@@ -141,6 +141,7 @@ class TedeeClient:
             ) = self.parse_lock_properties(lock_json)
             (
                 is_enabled_pullspring,
+                is_enabled_auto_pullspring,
                 duration_pullspring,
             ) = self.parse_pull_spring_settings(lock_json)
 
@@ -154,6 +155,7 @@ class TedeeClient:
                 is_charging,
                 state_change_result,
                 is_enabled_pullspring,
+                is_enabled_auto_pullspring,
                 duration_pullspring,
             )
 
@@ -203,6 +205,7 @@ class TedeeClient:
             if local_call_success:
                 (
                     lock.is_enabled_pullspring,
+                    lock.is_enabled_auto_pullspring,
                     lock.duration_pullspring,
                 ) = self.parse_pull_spring_settings(lock_json)
 
@@ -354,8 +357,9 @@ class TedeeClient:
         """Parse the pull spring settings"""
         device_settings = settings.get("deviceSettings", {})
         pull_spring_enabled = bool(device_settings.get("pullSpringEnabled", False))
+        pull_spring_auto_enabled = bool(device_settings.get("autoPullSpringEnabled", False))
         pull_spring_duration = device_settings.get("pullSpringDuration", 5)
-        return pull_spring_enabled, pull_spring_duration
+        return pull_spring_enabled, pull_spring_auto_enabled, pull_spring_duration
 
     def _calculate_secure_local_token(self) -> str:
         """Calculate the secure token"""


### PR DESCRIPTION
Add automatic pullspring toggle parsing from deviceSettings, first step to adding pull into HA.

I have added the following into the tedee HA integration locally and will create a follow up PR over there when I think the code is ready.

```py
"""Set up the Tedee lock entity."""
    coordinator = entry.runtime_data

    entities: list[TedeeLockEntity] = []
    for lock in coordinator.data.values():
        if lock.is_enabled_pullspring and lock.is_enabled_auto_pullspring:
            entities.append(TedeeLockWithAutoLatchEntity(lock, coordinator))
        elif lock.is_enabled_pullspring and not lock.is_enabled_auto_pullspring:
            entities.append(TedeeLockWithManualLatchEntity(lock, coordinator))
        else:
            entities.append(TedeeLockEntity(lock, coordinator))

    def _async_add_new_lock(lock_id: int) -> None:
        lock = coordinator.data[lock_id]
        if lock.is_enabled_pullspring and lock.is_enabled_auto_pullspring:
            async_add_entities([TedeeLockWithAutoLatchEntity(lock, coordinator)])
        elif lock.is_enabled_pullspring and not lock.is_enabled_auto_pullspring:
            async_add_entities([TedeeLockWithManualLatchEntity(lock, coordinator)])
        else:
            async_add_entities([TedeeLockEntity(lock, coordinator)])

    coordinator.new_lock_callbacks.append(_async_add_new_lock)

    async_add_entities(entities)

```

